### PR TITLE
PyYAML is not there in requirments.txt and setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ httpx>=0.26.0
 plyer>=2.1.0
 pywebio>=1.8.2
 Requests>=2.31.0
+PyYAML>=6.0.1

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
         'fake_useragent>=1.2.1',
         'pywebio>=1.8.2',
         'requests>=2.31.0',
-        'argparse>=1.4.0'
+        'argparse>=1.4.0',
+        'PyYAML>=6.0.1'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
# Issue

- While installing the tool in new version. YAML module was not there. So it is better to have `PyYAML` module in `requirments.txt` and `setup.py`.